### PR TITLE
Bump node to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: 'Test Coverage'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'message-square'


### PR DESCRIPTION
Github is now throwing warning when node v12 is used, and suggests bumping to v16 or higher.